### PR TITLE
Gnu Radio integration experiment

### DIFF
--- a/server/app/controllers/receive.py
+++ b/server/app/controllers/receive.py
@@ -178,7 +178,10 @@ def receive(station_id: str, args: RequestArguments):
     # Make charts
     station = repository.read_station(observation["station_id"])
     make_charts(observation, station, root)
-    return '', 204
+
+    # Make sure to return the observation id to the station. This may be useful if the station wants
+    # to update the observation in some way (send additional info or perhaps decide to delete it in the future).
+    return 'Observation %d received.' % obs_id, 204
 
 def make_charts(observation: Observation, station: Station,
         root:str=None):
@@ -186,13 +189,13 @@ def make_charts(observation: Observation, station: Station,
         root = app.config["storage"]['image_root']
 
     location = tle_diagrams.Location(station["lat"], station["lon"], 0)
-    
+
     chart_dir = os.path.join(root, "charts")
     get_chart_path = lambda type_, obs_id: os.path.join(
         chart_dir,
         "%s-%d.png" % (type_, obs_id)
     )
-    
+
     for type_, gen in [("by_time", tle_diagrams.generate_by_time_plot_png),
                     ("polar", tle_diagrams.generate_polar_plot_png)]:
         stream = gen(location, observation["tle"], observation["aos"],

--- a/station/recipes-satnogs/info.md
+++ b/station/recipes-satnogs/info.md
@@ -1,0 +1,3 @@
+The following *.grc files were imported from git@gitlab.com:librespacefoundation/satnogs/satnogs-flowgraphs.git
+and modified slightly.
+

--- a/station/recipes-satnogs/noaa_apt_decoder.grc
+++ b/station/recipes-satnogs/noaa_apt_decoder.grc
@@ -1,0 +1,918 @@
+options:
+  parameters:
+    author: Manolis Surligas, George Vardakis
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: A NOAA APT Decoder with automatic image synchronization
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: no_gui
+    hier_block_src_path: '.:'
+    id: satnogs_noaa_apt_decoder
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: run
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: NOAA APT Decoder
+    window_size: 2048,1080
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: audio_samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '48000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1296, 12.0]
+    rotation: 0
+    state: enabled
+- name: analog_wfm_rcv_0
+  id: analog_wfm_rcv
+  parameters:
+    affinity: ''
+    alias: ''
+    audio_decimation: '1'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    quad_rate: 4*4160*4
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [464, 620.0]
+    rotation: 0
+    state: enabled
+- name: antenna
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: str
+    value: '"RX"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [792, 12.0]
+    rotation: 0
+    state: enabled
+- name: band_pass_filter_0
+  id: band_pass_filter
+  parameters:
+    affinity: ''
+    alias: ''
+    beta: '6.76'
+    comment: ''
+    decim: '4'
+    gain: '1'
+    high_cutoff_freq: 4.2e3
+    interp: '1'
+    low_cutoff_freq: '500'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samp_rate: (4*4160*4 )
+    type: fir_filter_fff
+    width: '200'
+    win: firdes.WIN_HAMMING
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [728, 572.0]
+    rotation: 0
+    state: enabled
+- name: bb_freq
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: Baseband CORDIC frequency (if the device supports it)
+    short_id: ''
+    type: eng_float
+    value: '0.0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1832, 148.0]
+    rotation: 0
+    state: enabled
+- name: blocks_complex_to_mag_0
+  id: blocks_complex_to_mag
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1040, 632.0]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_0
+  id: blocks_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: 'Complex doppler corrected IQ over UDP.
+
+      Sample rate will need to be calculated and specified.
+
+      Example; use with: gr-satellites --udp --iq --udp_raw'
+    eof: 'True'
+    ipaddr: udp_dump_host
+    port: udp_dump_port
+    psize: '1472'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [864, 924]
+    rotation: 0
+    state: true
+- name: bw
+  id: parameter
+  parameters:
+    alias: ''
+    comment: 'The bandwidth should configure RF filters on some devices.
+
+      Set to 0.0 for automatic calculation.'
+    hide: none
+    label: Bandwidth
+    short_id: ''
+    type: eng_float
+    value: '0.0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1184, 12.0]
+    rotation: 0
+    state: enabled
+- name: dc_removal
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: Remove automatically the DC offset (if the device support it)
+    short_id: ''
+    type: str
+    value: '"False"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1672, 148.0]
+    rotation: 0
+    state: enabled
+- name: decoded_data_file_path
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: str
+    value: '"/tmp/.satnogs/data/data"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 860.0]
+    rotation: 0
+    state: enabled
+- name: dev_args
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: Device arguments
+    short_id: ''
+    type: str
+    value: '""'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [336, 12.0]
+    rotation: 0
+    state: enabled
+- name: doppler_correction_per_sec
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: intx
+    value: '20'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [176, 860.0]
+    rotation: 0
+    state: enabled
+- name: enable_iq_dump
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: intx
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [272, 780.0]
+    rotation: 0
+    state: enabled
+- name: file_path
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: str
+    value: '"test.wav"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [160, 780.0]
+    rotation: 180
+    state: enabled
+- name: flip_images
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: intx
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1408, 12.0]
+    rotation: 0
+    state: enabled
+- name: gain
+  id: parameter
+  parameters:
+    alias: ''
+    comment: "Generic gain value. \nEach Soapy module\nwill try to linearize this\n\
+      value by properly setting\nthe device specific gains."
+    hide: none
+    label: ''
+    short_id: ''
+    type: eng_float
+    value: '0.0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1040, 12.0]
+    rotation: 0
+    state: enabled
+- name: gain_mode
+  id: parameter
+  parameters:
+    alias: ''
+    comment: 'Set the gain mode of the Soapy.
+
+      Can be "Overall", "Specific"
+
+      or "Settings Field"'
+    hide: none
+    label: ''
+    short_id: ''
+    type: str
+    value: '"Overall"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [880, 12.0]
+    rotation: 0
+    state: enabled
+- name: hilbert_fc_0
+  id: hilbert_fc
+  parameters:
+    affinity: ''
+    alias: ''
+    beta: '6.76'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_taps: '65'
+    win: firdes.WIN_HAMMING
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [904, 628.0]
+    rotation: 0
+    state: enabled
+- name: iq_file_path
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: str
+    value: '"/tmp/iq.dat"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [400, 780.0]
+    rotation: 0
+    state: enabled
+- name: lo_offset
+  id: parameter
+  parameters:
+    alias: ''
+    comment: 'To avoid the SDR carrier at the DC
+
+      we shift the LO a little further'
+    hide: none
+    label: ''
+    short_id: ''
+    type: eng_float
+    value: 100e3
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [704, 12.0]
+    rotation: 0
+    state: enabled
+- name: low_pass_filter_0_0
+  id: low_pass_filter
+  parameters:
+    affinity: ''
+    alias: ''
+    beta: '6.76'
+    comment: "Perform a relaxed filter to increase \nthe performance of the auto frequency\n\
+      correction"
+    cutoff_freq: 4*4160*1.1
+    decim: '1'
+    gain: '1'
+    interp: '1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samp_rate: 4*4160*4
+    type: fir_filter_ccf
+    width: 1e3
+    win: firdes.WIN_HAMMING
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [264, 580.0]
+    rotation: 0
+    state: enabled
+- name: other_settings
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: Soapy Channel other settings
+    short_id: ''
+    type: str
+    value: '""'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1520, 148.0]
+    rotation: 0
+    state: enabled
+- name: pfb_arb_resampler_xxx_0
+  id: pfb_arb_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    atten: '100'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    nfilts: '32'
+    rrate: audio_samp_rate / (4*4160*4)
+    samp_delay: '0'
+    taps: ''
+    type: fff
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [728, 476.0]
+    rotation: 0
+    state: true
+- name: ppm
+  id: parameter
+  parameters:
+    alias: ''
+    comment: 'The frequency correction in PPM
+
+      to correct for a local oscillator frequency deviation'
+    hide: none
+    label: ''
+    short_id: ''
+    type: eng_float
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1584, 12.0]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_0_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '4'
+    fbw: '0'
+    interp: '1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: fff
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1184, 604.0]
+    rotation: 0
+    state: enabled
+- name: rigctl_port
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: intx
+    value: '4532'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [344, 860.0]
+    rotation: 0
+    state: enabled
+- name: rx_freq
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: eng_float
+    value: 100e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [624, 12.0]
+    rotation: 0
+    state: enabled
+- name: samp_rate_rx
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: Device Sampling rate
+    short_id: ''
+    type: eng_float
+    value: '2048000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [472, 12.0]
+    rotation: 0
+    state: enabled
+- name: satnogs_doppler_compensation_0
+  id: satnogs_doppler_compensation
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    compensate: '1'
+    fine_correction: '0'
+    lo_offset: lo_offset
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    out_samp_rate: 4*4160*4
+    samp_rate: samp_rate_rx
+    sat_freq: rx_freq
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [464, 220.0]
+    rotation: 0
+    state: true
+- name: satnogs_iq_sink_0_0
+  id: satnogs_iq_sink
+  parameters:
+    activate: enable_iq_dump
+    affinity: ''
+    alias: ''
+    append: 'False'
+    comment: ''
+    filename: iq_file_path
+    scale: '16768'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 684.0]
+    rotation: 180
+    state: enabled
+- name: satnogs_noaa_apt_sink_1
+  id: satnogs_noaa_apt_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    filename_png: decoded_data_file_path
+    flip: 'False'
+    height: '1800'
+    sync: 'True'
+    width: '2080'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1144, 708.0]
+    rotation: 180
+    state: true
+- name: satnogs_ogg_encoder_0
+  id: satnogs_ogg_encoder
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    filename: file_path
+    quality: '0.8'
+    samp_rate: audio_samp_rate
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [952, 484.0]
+    rotation: 0
+    state: enabled
+- name: satnogs_waterfall_sink_0_0
+  id: satnogs_waterfall_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    center_freq: rx_freq
+    comment: ''
+    fft_size: '1024'
+    filename: waterfall_file_path
+    mode: '1'
+    rps: '10'
+    samp_rate: 4*4160*4
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 500.0]
+    rotation: 180
+    state: enabled
+- name: soapy_rx_device
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: str
+    value: '"driver=rtlsdr"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [216, 12.0]
+    rotation: 0
+    state: enabled
+- name: soapy_source_0_0
+  id: soapy_source
+  parameters:
+    affinity: ''
+    agc0: 'False'
+    agc1: 'False'
+    alias: ''
+    amp_gain0: '0'
+    ant0: antenna
+    ant1: RX2
+    args: dev_args
+    balance0: '0'
+    balance1: '0'
+    bw0: bw
+    bw1: '0'
+    center_freq0: rx_freq - lo_offset
+    center_freq1: '0'
+    clock_rate: '0'
+    clock_source: ''
+    comment: ''
+    correction0: ppm
+    correction1: '0'
+    dc_offset0: '0'
+    dc_offset1: '0'
+    dc_removal0: dc_removal
+    dc_removal1: 'True'
+    dev: soapy_rx_device
+    devname: custom
+    gain_mode0: gain_mode
+    gain_mode1: Overall
+    ifgr_gain: '59'
+    lna_gain0: '10'
+    lna_gain1: '10'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mix_gain0: '10'
+    nchan: '1'
+    nco_freq0: bb_freq
+    nco_freq1: '0'
+    overall_gain0: gain
+    overall_gain1: '10'
+    pga_gain0: '24'
+    pga_gain1: '24'
+    rfgr_gain: '9'
+    rxvga1_gain: '5'
+    rxvga2_gain: '0'
+    samp_rate: samp_rate_rx
+    sdrplay_agc_setpoint: '-30'
+    sdrplay_biastee: 'True'
+    sdrplay_dabnotch: 'False'
+    sdrplay_if_mode: Zero-IF
+    sdrplay_rfnotch: 'False'
+    settings0: other_settings
+    settings1: ''
+    stream_args: stream_args
+    tia_gain0: '0'
+    tia_gain1: '0'
+    tune_args0: tune_args
+    tune_args1: ''
+    tuner_gain0: '10'
+    type: fc32
+    vga_gain0: '10'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [208, 148.0]
+    rotation: 0
+    state: true
+- name: stream_args
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: Soapy Stream arguments
+    short_id: ''
+    type: str
+    value: '""'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1184, 148.0]
+    rotation: 0
+    state: enabled
+- name: sync
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: intx
+    value: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1504, 12.0]
+    rotation: 0
+    state: enabled
+- name: tune_args
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: Soapy Channel Tune arguments
+    short_id: ''
+    type: str
+    value: '""'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1360, 148.0]
+    rotation: 0
+    state: enabled
+- name: udp_IP
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: str
+    value: '"127.0.0.1"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [512, 780.0]
+    rotation: 0
+    state: enabled
+- name: udp_dump_host
+  id: parameter
+  parameters:
+    alias: ''
+    comment: 'None to disable
+
+      ''127.0.0.1'' to enable on loopback'
+    hide: none
+    label: ''
+    short_id: ''
+    type: str
+    value: '""'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [788, 812]
+    rotation: 0
+    state: enabled
+- name: udp_dump_port
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: intx
+    value: '57356'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [909, 812]
+    rotation: 0
+    state: enabled
+- name: udp_port
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: intx
+    value: '16887'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [440, 860.0]
+    rotation: 0
+    state: enabled
+- name: virtual_sink_0
+  id: virtual_sink
+  parameters:
+    alias: ''
+    comment: ''
+    stream_id: doppler_corrected
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [720, 260.0]
+    rotation: 0
+    state: true
+- name: virtual_source_0
+  id: virtual_source
+  parameters:
+    alias: ''
+    comment: ''
+    stream_id: doppler_corrected
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 628.0]
+    rotation: 0
+    state: true
+- name: virtual_source_0_0
+  id: virtual_source
+  parameters:
+    alias: ''
+    comment: ''
+    stream_id: doppler_corrected
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [645, 948]
+    rotation: 0
+    state: true
+- name: waterfall_file_path
+  id: parameter
+  parameters:
+    alias: ''
+    comment: ''
+    hide: none
+    label: ''
+    short_id: ''
+    type: str
+    value: '"/tmp/waterfall.dat"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 780.0]
+    rotation: 0
+    state: enabled
+
+connections:
+- [analog_wfm_rcv_0, '0', band_pass_filter_0, '0']
+- [analog_wfm_rcv_0, '0', pfb_arb_resampler_xxx_0, '0']
+- [band_pass_filter_0, '0', hilbert_fc_0, '0']
+- [blocks_complex_to_mag_0, '0', rational_resampler_xxx_0_0, '0']
+- [hilbert_fc_0, '0', blocks_complex_to_mag_0, '0']
+- [low_pass_filter_0_0, '0', analog_wfm_rcv_0, '0']
+- [pfb_arb_resampler_xxx_0, '0', satnogs_ogg_encoder_0, '0']
+- [rational_resampler_xxx_0_0, '0', satnogs_noaa_apt_sink_1, '0']
+- [satnogs_doppler_compensation_0, '0', virtual_sink_0, '0']
+- [soapy_source_0_0, '0', satnogs_doppler_compensation_0, '0']
+- [virtual_source_0, '0', low_pass_filter_0_0, '0']
+- [virtual_source_0, '0', satnogs_iq_sink_0_0, '0']
+- [virtual_source_0, '0', satnogs_waterfall_sink_0_0, '0']
+- [virtual_source_0_0, '0', blocks_udp_sink_0_0, '0']
+
+metadata:
+  file_format: 1

--- a/station/recipes-satnogs/satnogs_noaa_apt_decoder.py
+++ b/station/recipes-satnogs/satnogs_noaa_apt_decoder.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#
+# SPDX-License-Identifier: GPL-3.0
+#
+# GNU Radio Python Flow Graph
+# Title: NOAA APT Decoder
+# Author: Manolis Surligas, George Vardakis
+# Description: A NOAA APT Decoder with automatic image synchronization
+# GNU Radio version: 3.8.1.0
+
+from gnuradio import analog
+from gnuradio import blocks
+from gnuradio import filter
+from gnuradio.filter import firdes
+from gnuradio import gr
+import sys
+import signal
+from argparse import ArgumentParser
+from gnuradio.eng_arg import eng_float, intx
+from gnuradio import eng_notation
+from gnuradio.filter import pfb
+import satnogs
+import soapy
+import distutils
+from distutils import util
+
+
+class satnogs_noaa_apt_decoder(gr.top_block):
+
+    def __init__(self, antenna="RX", bb_freq=0.0, bw=0.0, dc_removal="False", decoded_data_file_path="/tmp/.satnogs/data/data", dev_args="", doppler_correction_per_sec=20, enable_iq_dump=0, file_path="test.wav", flip_images=0, gain=0.0, gain_mode="Overall", iq_file_path="/tmp/iq.dat", lo_offset=100e3, other_settings="", ppm=0, rigctl_port=4532, rx_freq=100e6, samp_rate_rx=2048000, soapy_rx_device="driver=rtlsdr", stream_args="", sync=1, tune_args="", udp_IP="127.0.0.1", udp_dump_host="", udp_dump_port=57356, udp_port=16887, waterfall_file_path="/tmp/waterfall.dat"):
+        gr.top_block.__init__(self, "NOAA APT Decoder")
+
+        ##################################################
+        # Parameters
+        ##################################################
+        self.antenna = antenna
+        self.bb_freq = bb_freq
+        self.bw = bw
+        self.dc_removal = dc_removal
+        self.decoded_data_file_path = decoded_data_file_path
+        self.dev_args = dev_args
+        self.doppler_correction_per_sec = doppler_correction_per_sec
+        self.enable_iq_dump = enable_iq_dump
+        self.file_path = file_path
+        self.flip_images = flip_images
+        self.gain = gain
+        self.gain_mode = gain_mode
+        self.iq_file_path = iq_file_path
+        self.lo_offset = lo_offset
+        self.other_settings = other_settings
+        self.ppm = ppm
+        self.rigctl_port = rigctl_port
+        self.rx_freq = rx_freq
+        self.samp_rate_rx = samp_rate_rx
+        self.soapy_rx_device = soapy_rx_device
+        self.stream_args = stream_args
+        self.sync = sync
+        self.tune_args = tune_args
+        self.udp_IP = udp_IP
+        self.udp_dump_host = udp_dump_host
+        self.udp_dump_port = udp_dump_port
+        self.udp_port = udp_port
+        self.waterfall_file_path = waterfall_file_path
+
+        ##################################################
+        # Variables
+        ##################################################
+        self.audio_samp_rate = audio_samp_rate = 48000
+
+        ##################################################
+        # Blocks
+        ##################################################
+        self.soapy_source_0_0 = None
+        # Make sure that the gain mode is valid
+        if(gain_mode not in ['Overall', 'Specific', 'Settings Field']):
+            raise ValueError("Wrong gain mode on channel 0. Allowed gain modes: "
+                  "['Overall', 'Specific', 'Settings Field']")
+
+        dev = soapy_rx_device
+
+        # Stream arguments for every activated stream
+        tune_args = [tune_args]
+        settings = [other_settings]
+
+        # Setup the device arguments
+        dev_args = dev_args
+
+        self.soapy_source_0_0 = soapy.source(1, dev, dev_args, stream_args,
+                                  tune_args, settings, samp_rate_rx, "fc32")
+
+
+
+        self.soapy_source_0_0.set_dc_removal(0,bool(distutils.util.strtobool(dc_removal)))
+
+        # Set up DC offset. If set to (0, 0) internally the source block
+        # will handle the case if no DC offset correction is supported
+        self.soapy_source_0_0.set_dc_offset(0,0)
+
+        # Setup IQ Balance. If set to (0, 0) internally the source block
+        # will handle the case if no IQ balance correction is supported
+        self.soapy_source_0_0.set_iq_balance(0,0)
+
+        self.soapy_source_0_0.set_agc(0,False)
+
+        # generic frequency setting should be specified first
+        self.soapy_source_0_0.set_frequency(0, rx_freq - lo_offset)
+
+        self.soapy_source_0_0.set_frequency(0,"BB",bb_freq)
+
+        # Setup Frequency correction. If set to 0 internally the source block
+        # will handle the case if no frequency correction is supported
+        self.soapy_source_0_0.set_frequency_correction(0,ppm)
+
+        self.soapy_source_0_0.set_antenna(0,antenna)
+
+        self.soapy_source_0_0.set_bandwidth(0,bw)
+
+        if(gain_mode != 'Settings Field'):
+            # pass is needed, in case the template does not evaluare anything
+            pass
+            self.soapy_source_0_0.set_gain(0,gain)
+        self.satnogs_waterfall_sink_0_0 = satnogs.waterfall_sink(4*4160*4, rx_freq, 10, 1024, waterfall_file_path, 1)
+        self.satnogs_ogg_encoder_0 = satnogs.ogg_encoder(file_path, audio_samp_rate, 0.8)
+        self.satnogs_noaa_apt_sink_1 = satnogs.noaa_apt_sink(decoded_data_file_path, 2080, 1800, True, False)
+        self.satnogs_iq_sink_0_0 = satnogs.iq_sink(16768, iq_file_path, False, enable_iq_dump)
+        self.satnogs_doppler_compensation_0 = satnogs.doppler_compensation(samp_rate_rx, rx_freq, lo_offset, 4*4160*4, 1, 0)
+        self.rational_resampler_xxx_0_0 = filter.rational_resampler_fff(
+                interpolation=1,
+                decimation=4,
+                taps=None,
+                fractional_bw=None)
+        self.pfb_arb_resampler_xxx_0 = pfb.arb_resampler_fff(
+            audio_samp_rate / (4*4160*4),
+            taps=None,
+            flt_size=32)
+        self.pfb_arb_resampler_xxx_0.declare_sample_delay(0)
+        self.low_pass_filter_0_0 = filter.fir_filter_ccf(
+            1,
+            firdes.low_pass(
+                1,
+                4*4160*4,
+                4*4160*1.1,
+                1e3,
+                firdes.WIN_HAMMING,
+                6.76))
+        self.hilbert_fc_0 = filter.hilbert_fc(65, firdes.WIN_HAMMING, 6.76)
+        self.blocks_udp_sink_0_0 = blocks.udp_sink(gr.sizeof_gr_complex*1, udp_dump_host, udp_dump_port, 1472, True)
+        self.blocks_complex_to_mag_0 = blocks.complex_to_mag(1)
+        self.band_pass_filter_0 = filter.fir_filter_fff(
+            4,
+            firdes.band_pass(
+                1,
+                (4*4160*4 ),
+                500,
+                4.2e3,
+                200,
+                firdes.WIN_HAMMING,
+                6.76))
+        self.analog_wfm_rcv_0 = analog.wfm_rcv(
+        	quad_rate=4*4160*4,
+        	audio_decimation=1,
+        )
+
+
+
+        ##################################################
+        # Connections
+        ##################################################
+        self.connect((self.analog_wfm_rcv_0, 0), (self.band_pass_filter_0, 0))
+        self.connect((self.analog_wfm_rcv_0, 0), (self.pfb_arb_resampler_xxx_0, 0))
+        self.connect((self.band_pass_filter_0, 0), (self.hilbert_fc_0, 0))
+        self.connect((self.blocks_complex_to_mag_0, 0), (self.rational_resampler_xxx_0_0, 0))
+        self.connect((self.hilbert_fc_0, 0), (self.blocks_complex_to_mag_0, 0))
+        self.connect((self.low_pass_filter_0_0, 0), (self.analog_wfm_rcv_0, 0))
+        self.connect((self.pfb_arb_resampler_xxx_0, 0), (self.satnogs_ogg_encoder_0, 0))
+        self.connect((self.rational_resampler_xxx_0_0, 0), (self.satnogs_noaa_apt_sink_1, 0))
+        self.connect((self.satnogs_doppler_compensation_0, 0), (self.blocks_udp_sink_0_0, 0))
+        self.connect((self.satnogs_doppler_compensation_0, 0), (self.low_pass_filter_0_0, 0))
+        self.connect((self.satnogs_doppler_compensation_0, 0), (self.satnogs_iq_sink_0_0, 0))
+        self.connect((self.satnogs_doppler_compensation_0, 0), (self.satnogs_waterfall_sink_0_0, 0))
+        self.connect((self.soapy_source_0_0, 0), (self.satnogs_doppler_compensation_0, 0))
+
+
+    def get_antenna(self):
+        return self.antenna
+
+    def set_antenna(self, antenna):
+        self.antenna = antenna
+        self.soapy_source_0_0.set_antenna(0,self.antenna)
+
+    def get_bb_freq(self):
+        return self.bb_freq
+
+    def set_bb_freq(self, bb_freq):
+        self.bb_freq = bb_freq
+        self.soapy_source_0_0.set_frequency(0,"BB",self.bb_freq)
+
+    def get_bw(self):
+        return self.bw
+
+    def set_bw(self, bw):
+        self.bw = bw
+        self.soapy_source_0_0.set_bandwidth(0,self.bw)
+
+    def get_dc_removal(self):
+        return self.dc_removal
+
+    def set_dc_removal(self, dc_removal):
+        self.dc_removal = dc_removal
+        self.soapy_source_0_0.set_dc_removal(0,bool(distutils.util.strtobool(self.dc_removal)))
+
+    def get_decoded_data_file_path(self):
+        return self.decoded_data_file_path
+
+    def set_decoded_data_file_path(self, decoded_data_file_path):
+        self.decoded_data_file_path = decoded_data_file_path
+
+    def get_dev_args(self):
+        return self.dev_args
+
+    def set_dev_args(self, dev_args):
+        self.dev_args = dev_args
+
+    def get_doppler_correction_per_sec(self):
+        return self.doppler_correction_per_sec
+
+    def set_doppler_correction_per_sec(self, doppler_correction_per_sec):
+        self.doppler_correction_per_sec = doppler_correction_per_sec
+
+    def get_enable_iq_dump(self):
+        return self.enable_iq_dump
+
+    def set_enable_iq_dump(self, enable_iq_dump):
+        self.enable_iq_dump = enable_iq_dump
+
+    def get_file_path(self):
+        return self.file_path
+
+    def set_file_path(self, file_path):
+        self.file_path = file_path
+
+    def get_flip_images(self):
+        return self.flip_images
+
+    def set_flip_images(self, flip_images):
+        self.flip_images = flip_images
+
+    def get_gain(self):
+        return self.gain
+
+    def set_gain(self, gain):
+        self.gain = gain
+        self.soapy_source_0_0.set_gain(0, self.gain)
+
+    def get_gain_mode(self):
+        return self.gain_mode
+
+    def set_gain_mode(self, gain_mode):
+        self.gain_mode = gain_mode
+
+    def get_iq_file_path(self):
+        return self.iq_file_path
+
+    def set_iq_file_path(self, iq_file_path):
+        self.iq_file_path = iq_file_path
+
+    def get_lo_offset(self):
+        return self.lo_offset
+
+    def set_lo_offset(self, lo_offset):
+        self.lo_offset = lo_offset
+        self.soapy_source_0_0.set_frequency(0, self.rx_freq - self.lo_offset)
+
+    def get_other_settings(self):
+        return self.other_settings
+
+    def set_other_settings(self, other_settings):
+        self.other_settings = other_settings
+
+    def get_ppm(self):
+        return self.ppm
+
+    def set_ppm(self, ppm):
+        self.ppm = ppm
+        self.soapy_source_0_0.set_frequency_correction(0,self.ppm)
+
+    def get_rigctl_port(self):
+        return self.rigctl_port
+
+    def set_rigctl_port(self, rigctl_port):
+        self.rigctl_port = rigctl_port
+
+    def get_rx_freq(self):
+        return self.rx_freq
+
+    def set_rx_freq(self, rx_freq):
+        self.rx_freq = rx_freq
+        self.soapy_source_0_0.set_frequency(0, self.rx_freq - self.lo_offset)
+
+    def get_samp_rate_rx(self):
+        return self.samp_rate_rx
+
+    def set_samp_rate_rx(self, samp_rate_rx):
+        self.samp_rate_rx = samp_rate_rx
+
+    def get_soapy_rx_device(self):
+        return self.soapy_rx_device
+
+    def set_soapy_rx_device(self, soapy_rx_device):
+        self.soapy_rx_device = soapy_rx_device
+
+    def get_stream_args(self):
+        return self.stream_args
+
+    def set_stream_args(self, stream_args):
+        self.stream_args = stream_args
+
+    def get_sync(self):
+        return self.sync
+
+    def set_sync(self, sync):
+        self.sync = sync
+
+    def get_tune_args(self):
+        return self.tune_args
+
+    def set_tune_args(self, tune_args):
+        self.tune_args = tune_args
+
+    def get_udp_IP(self):
+        return self.udp_IP
+
+    def set_udp_IP(self, udp_IP):
+        self.udp_IP = udp_IP
+
+    def get_udp_dump_host(self):
+        return self.udp_dump_host
+
+    def set_udp_dump_host(self, udp_dump_host):
+        self.udp_dump_host = udp_dump_host
+
+    def get_udp_dump_port(self):
+        return self.udp_dump_port
+
+    def set_udp_dump_port(self, udp_dump_port):
+        self.udp_dump_port = udp_dump_port
+
+    def get_udp_port(self):
+        return self.udp_port
+
+    def set_udp_port(self, udp_port):
+        self.udp_port = udp_port
+
+    def get_waterfall_file_path(self):
+        return self.waterfall_file_path
+
+    def set_waterfall_file_path(self, waterfall_file_path):
+        self.waterfall_file_path = waterfall_file_path
+
+    def get_audio_samp_rate(self):
+        return self.audio_samp_rate
+
+    def set_audio_samp_rate(self, audio_samp_rate):
+        self.audio_samp_rate = audio_samp_rate
+        self.pfb_arb_resampler_xxx_0.set_rate(self.audio_samp_rate / (4*4160*4))
+
+
+
+
+def argument_parser():
+    description = 'A NOAA APT Decoder with automatic image synchronization'
+    parser = ArgumentParser(description=description)
+    parser.add_argument(
+        "--antenna", dest="antenna", type=str, default="RX",
+        help="Set antenna [default=%(default)r]")
+    parser.add_argument(
+        "--bb-freq", dest="bb_freq", type=eng_float, default="0.0",
+        help="Set Baseband CORDIC frequency (if the device supports it) [default=%(default)r]")
+    parser.add_argument(
+        "--bw", dest="bw", type=eng_float, default="0.0",
+        help="Set Bandwidth [default=%(default)r]")
+    parser.add_argument(
+        "--dc-removal", dest="dc_removal", type=str, default="False",
+        help="Set Remove automatically the DC offset (if the device support it) [default=%(default)r]")
+    parser.add_argument(
+        "--decoded-data-file-path", dest="decoded_data_file_path", type=str, default="/tmp/.satnogs/data/data",
+        help="Set decoded_data_file_path [default=%(default)r]")
+    parser.add_argument(
+        "--dev-args", dest="dev_args", type=str, default="",
+        help="Set Device arguments [default=%(default)r]")
+    parser.add_argument(
+        "--doppler-correction-per-sec", dest="doppler_correction_per_sec", type=intx, default=20,
+        help="Set doppler_correction_per_sec [default=%(default)r]")
+    parser.add_argument(
+        "--enable-iq-dump", dest="enable_iq_dump", type=intx, default=0,
+        help="Set enable_iq_dump [default=%(default)r]")
+    parser.add_argument(
+        "--file-path", dest="file_path", type=str, default="test.wav",
+        help="Set file_path [default=%(default)r]")
+    parser.add_argument(
+        "--flip-images", dest="flip_images", type=intx, default=0,
+        help="Set flip_images [default=%(default)r]")
+    parser.add_argument(
+        "--gain", dest="gain", type=eng_float, default="0.0",
+        help="Set gain [default=%(default)r]")
+    parser.add_argument(
+        "--gain-mode", dest="gain_mode", type=str, default="Overall",
+        help="Set gain_mode [default=%(default)r]")
+    parser.add_argument(
+        "--iq-file-path", dest="iq_file_path", type=str, default="/tmp/iq.dat",
+        help="Set iq_file_path [default=%(default)r]")
+    parser.add_argument(
+        "--lo-offset", dest="lo_offset", type=eng_float, default="100.0k",
+        help="Set lo_offset [default=%(default)r]")
+    parser.add_argument(
+        "--other-settings", dest="other_settings", type=str, default="",
+        help="Set Soapy Channel other settings [default=%(default)r]")
+    parser.add_argument(
+        "--ppm", dest="ppm", type=eng_float, default="0.0",
+        help="Set ppm [default=%(default)r]")
+    parser.add_argument(
+        "--rigctl-port", dest="rigctl_port", type=intx, default=4532,
+        help="Set rigctl_port [default=%(default)r]")
+    parser.add_argument(
+        "--rx-freq", dest="rx_freq", type=eng_float, default="100.0M",
+        help="Set rx_freq [default=%(default)r]")
+    parser.add_argument(
+        "--samp-rate-rx", dest="samp_rate_rx", type=eng_float, default="2.048M",
+        help="Set Device Sampling rate [default=%(default)r]")
+    parser.add_argument(
+        "--soapy-rx-device", dest="soapy_rx_device", type=str, default="driver=rtlsdr",
+        help="Set soapy_rx_device [default=%(default)r]")
+    parser.add_argument(
+        "--stream-args", dest="stream_args", type=str, default="",
+        help="Set Soapy Stream arguments [default=%(default)r]")
+    parser.add_argument(
+        "--sync", dest="sync", type=intx, default=1,
+        help="Set sync [default=%(default)r]")
+    parser.add_argument(
+        "--tune-args", dest="tune_args", type=str, default="",
+        help="Set Soapy Channel Tune arguments [default=%(default)r]")
+    parser.add_argument(
+        "--udp-IP", dest="udp_IP", type=str, default="127.0.0.1",
+        help="Set udp_IP [default=%(default)r]")
+    parser.add_argument(
+        "--udp-dump-host", dest="udp_dump_host", type=str, default="",
+        help="Set udp_dump_host [default=%(default)r]")
+    parser.add_argument(
+        "--udp-dump-port", dest="udp_dump_port", type=intx, default=57356,
+        help="Set udp_dump_port [default=%(default)r]")
+    parser.add_argument(
+        "--udp-port", dest="udp_port", type=intx, default=16887,
+        help="Set udp_port [default=%(default)r]")
+    parser.add_argument(
+        "--waterfall-file-path", dest="waterfall_file_path", type=str, default="/tmp/waterfall.dat",
+        help="Set waterfall_file_path [default=%(default)r]")
+    return parser
+
+
+def main(top_block_cls=satnogs_noaa_apt_decoder, options=None):
+    if options is None:
+        options = argument_parser().parse_args()
+    tb = top_block_cls(antenna=options.antenna, bb_freq=options.bb_freq, bw=options.bw, dc_removal=options.dc_removal, decoded_data_file_path=options.decoded_data_file_path, dev_args=options.dev_args, doppler_correction_per_sec=options.doppler_correction_per_sec, enable_iq_dump=options.enable_iq_dump, file_path=options.file_path, flip_images=options.flip_images, gain=options.gain, gain_mode=options.gain_mode, iq_file_path=options.iq_file_path, lo_offset=options.lo_offset, other_settings=options.other_settings, ppm=options.ppm, rigctl_port=options.rigctl_port, rx_freq=options.rx_freq, samp_rate_rx=options.samp_rate_rx, soapy_rx_device=options.soapy_rx_device, stream_args=options.stream_args, sync=options.sync, tune_args=options.tune_args, udp_IP=options.udp_IP, udp_dump_host=options.udp_dump_host, udp_dump_port=options.udp_dump_port, udp_port=options.udp_port, waterfall_file_path=options.waterfall_file_path)
+
+    def sig_handler(sig=None, frame=None):
+        tb.stop()
+        tb.wait()
+
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, sig_handler)
+    signal.signal(signal.SIGTERM, sig_handler)
+
+    tb.start()
+
+    tb.wait()
+
+
+if __name__ == '__main__':
+    main()

--- a/station/recipes/__init__.py
+++ b/station/recipes/__init__.py
@@ -1,5 +1,6 @@
 import recipes.noaa_apt
 import recipes.meteor_qpsk
+import recipes.noaa_apt_gr
 
 # Each recipe should be registered in this dictionary
 recipes = {

--- a/station/recipes/__init__.py
+++ b/station/recipes/__init__.py
@@ -4,6 +4,7 @@ import recipes.meteor_qpsk
 # Each recipe should be registered in this dictionary
 recipes = {
     'noaa-apt': recipes.noaa_apt.execute,
+    'noaa-apt-gr': recipes.noaa_apt_gr.execute,
     'meteor-qpsk': recipes.meteor_qpsk.execute
 }
 

--- a/station/recipes/noaa_apt_gr.py
+++ b/station/recipes/noaa_apt_gr.py
@@ -28,7 +28,7 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
     #  --samp-rate-rx=3000000 --antenna RX --gain 45 --bw 41000
 
     # TODO: Some of those parameters should be configurable.
-    soapy_rx_device = "driver=airspy"
+    soapy_rx_device = "driver=airspy,bias=1"
     sample_rate_rx = 3000000 # number of samples per second
     gain = 45 # 45 is max for airspy, rtlsdr can go up to 49.6
     bandwidth = 36000 # specify the received bandwidth in Hz

--- a/station/recipes/noaa_apt_gr.py
+++ b/station/recipes/noaa_apt_gr.py
@@ -3,7 +3,9 @@
 from contextlib import suppress
 from datetime import timedelta
 import os.path
+from os import remove
 import signal
+import waterfall
 
 import sh
 
@@ -16,11 +18,16 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
     signal_path = os.path.join(working_dir, "signal.wav")
     product_path = os.path.join(working_dir, "product.png")
     log_path = os.path.join(working_dir, "session.log")
-    waterfall_path = os.path.join(working_dir, "waterfall.dat")
+    waterfall_path = os.path.join(working_dir, "waterfall.png")
+
+    # TODO: If enabled, bias-T should be enabled
+
+    # Here's the command that can be used to receive the transmission.
 
     #./satnogs_noaa_apt_decoder.py --soapy-rx-device="driver=airspy" --rx-freq 137.9125M --decoded-data-file-path=/home/pi/observations/satnogs/decoded.png
     #  --samp-rate-rx=3000000 --antenna RX --gain 45 --bw 41000
 
+    # TODO: Some of those parameters should be configurable.
     soapy_rx_device = "driver=airspy"
     sample_rate_rx = 3000000 # number of samples per second
     gain = 45 # 45 is max for airspy, rtlsdr can go up to 49.6
@@ -37,6 +44,9 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
     logfile.write("bandwidth=%d" % bandwidth)
     logfile.flush()
 
+    waterfall_dat = waterfall_path + ".dat"
+
+
     # Run rtl_fm/rx_fm - this records the actual samples from the RTL device
     with suppress(sh.TimeoutException):
         sh.satnogs_noaa_apt_decoder(
@@ -52,7 +62,7 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
             "--bw", bandwidth,
             # now set up the files
             "--decoded-data-file-path", product_path,
-            "--waterfall-file-path", waterfall_path,
+            "--waterfall-file-path", waterfall_dat,
             "--file-path", signal_path,
             _timeout=duration.total_seconds(),
             _timeout_signal=signal.SIGTERM,
@@ -61,6 +71,16 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
             _err=logfile
         )
     logfile.flush()
+
+    # The GNU Radio pipeline generated raw waterfall data, which is reasonably big (30M or so).
+    # We want to convert it into easily browseable PNG file.
+    logfile.write("Converting waterfall data: %s to %s" % (waterfall_dat, waterfall_path))
+    w = waterfall.Waterfall(waterfall_dat)
+    w.plot(waterfall_path)
+
+    # Remove raw waterfall data, we don't need it.
+    os.remove(waterfall_dat)
+
     logfile.close()
 
     return [

--- a/station/recipes/noaa_apt_gr.py
+++ b/station/recipes/noaa_apt_gr.py
@@ -38,10 +38,10 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
     # flush, the logging order gets completely messed up.
     logfile = open(log_path, "w")
     logfile.write("---satnogs_noaa_apt_decoder-------\n")
-    logfile.write("soapy_rx_device=%s" % soapy_rx_device)
-    logfile.write("sample_rate_rx=%d" % sample_rate_rx)
-    logfile.write("gain=%f" % gain)
-    logfile.write("bandwidth=%d" % bandwidth)
+    logfile.write("soapy_rx_device=%s\n" % soapy_rx_device)
+    logfile.write("sample_rate_rx=%d\n" % sample_rate_rx)
+    logfile.write("gain=%f\n" % gain)
+    logfile.write("bandwidth=%d\n" % bandwidth)
     logfile.flush()
 
     waterfall_dat = waterfall_path + ".dat"

--- a/station/recipes/noaa_apt_gr.py
+++ b/station/recipes/noaa_apt_gr.py
@@ -1,0 +1,67 @@
+# This is a recipe for NOAA APT signal decoding using GNU RADIO
+
+from contextlib import suppress
+from datetime import timedelta
+import os.path
+import signal
+
+import sh
+
+from recipes.helpers import set_sh_defaults
+
+
+@set_sh_defaults
+def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
+
+    signal_path = os.path.join(working_dir, "signal.wav")
+    product_path = os.path.join(working_dir, "product.png")
+    log_path = os.path.join(working_dir, "session.log")
+    waterfall_path = os.path.join(working_dir, "waterfall.dat")
+
+    #./satnogs_noaa_apt_decoder.py --soapy-rx-device="driver=airspy" --rx-freq 137.9125M --decoded-data-file-path=/home/pi/observations/satnogs/decoded.png
+    #  --samp-rate-rx=3000000 --antenna RX --gain 45 --bw 41000
+
+    soapy_rx_device = "driver=airspy"
+    sample_rate_rx = 3000000 # number of samples per second
+    gain = 45 # 45 is max for airspy, rtlsdr can go up to 49.6
+    bandwidth = 36000 # specify the received bandwidth in Hz
+
+    # Let's log the operations done by the tools to a log file. We need to flush it
+    # frequently, because this file stream is also used capture tools output. Without
+    # flush, the logging order gets completely messed up.
+    logfile = open(log_path, "w")
+    logfile.write("---rtl_fm log-------\n")
+    logfile.flush()
+
+    # Run rtl_fm/rx_fm - this records the actual samples from the RTL device
+    with suppress(sh.TimeoutException):
+        sh.satnogs_noaa_apt_decoder.py(
+            # specify the device used for reception (driver=rtlsdr or driver=airspy works)
+            "--soapy-rx-device", soapy_rx_device,
+            # the receiving frequency
+            "--rx-freq", frequency,
+            # specify the gain
+            "--gain", gain,
+            # number of samples/s
+            "--samp-rate-rx=", sample_rate_rx,
+            # How arctan is computed. We don't test other options.
+            "--bw", bandwidth,
+            # now set up the files
+            "--decoded-data-file-path", product_path,
+            "--waterfall-file-path", waterfall_path,
+            "--file-path", signal_path,
+            _timeout=duration.total_seconds(),
+            _timeout_signal=signal.SIGTERM,
+
+            # rtl_fm and rx_fm both print messages on stderr
+            _err=logfile
+        )
+    logfile.flush()
+    logfile.close()
+
+    return [
+        ("SIGNAL", signal_path),
+        ("PRODUCT", product_path),
+        ("LOG", log_path),
+        ("WATERFALL", waterfall_path)
+    ]

--- a/station/recipes/noaa_apt_gr.py
+++ b/station/recipes/noaa_apt_gr.py
@@ -30,12 +30,12 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
     # frequently, because this file stream is also used capture tools output. Without
     # flush, the logging order gets completely messed up.
     logfile = open(log_path, "w")
-    logfile.write("---rtl_fm log-------\n")
+    logfile.write("---satnogs_noaa_apt_decoder-------\n")
     logfile.flush()
 
     # Run rtl_fm/rx_fm - this records the actual samples from the RTL device
     with suppress(sh.TimeoutException):
-        sh.satnogs_noaa_apt_decoder.py(
+        sh.satnogs_noaa_apt_decoder(
             # specify the device used for reception (driver=rtlsdr or driver=airspy works)
             "--soapy-rx-device", soapy_rx_device,
             # the receiving frequency
@@ -43,7 +43,7 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
             # specify the gain
             "--gain", gain,
             # number of samples/s
-            "--samp-rate-rx=", sample_rate_rx,
+            "--samp-rate-rx", sample_rate_rx,
             # How arctan is computed. We don't test other options.
             "--bw", bandwidth,
             # now set up the files

--- a/station/recipes/noaa_apt_gr.py
+++ b/station/recipes/noaa_apt_gr.py
@@ -31,6 +31,10 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
     # flush, the logging order gets completely messed up.
     logfile = open(log_path, "w")
     logfile.write("---satnogs_noaa_apt_decoder-------\n")
+    logfile.write("soapy_rx_device=%s" % soapy_rx_device)
+    logfile.write("sample_rate_rx=%d" % sample_rate_rx)
+    logfile.write("gain=%f" % gain)
+    logfile.write("bandwidth=%d" % bandwidth)
     logfile.flush()
 
     # Run rtl_fm/rx_fm - this records the actual samples from the RTL device

--- a/station/waterfall.py
+++ b/station/waterfall.py
@@ -1,0 +1,156 @@
+# This file is heavily based on waterfall.py from satnogs-client.
+
+import matplotlib
+import numpy as np
+import sys
+
+matplotlib.use('Agg')
+
+import matplotlib.pyplot as plt
+
+OFFSET_IN_STDS = -2.0
+SCALE_IN_STDS = 8.0
+
+class Waterfall():
+    """
+    Parse waterfall data file
+
+    :param datafile_path: Path to data file
+    :type datafile_path: str_array
+    """
+    def __init__(self, datafile_path, logger=None):
+        """
+        Class constructor
+        """
+        self.logger = logger or sys.stdout
+        self.data = self._get_waterfall(datafile_path)
+
+    def plot(self, figure_path, vmin=None, vmax=None):
+        """
+        Plot waterfall into a figure
+
+        :param figure_path: Path of figure file to save
+        :type figure_path: str
+        :param value_range: Minimum and maximum value range
+        :type value_range: tuple
+        """
+        tmin = np.min(self.data['data']['tabs'] / 1000000.0)
+        tmax = np.max(self.data['data']['tabs'] / 1000000.0)
+        fmin = np.min(self.data['freq'] / 1000.0)
+        fmax = np.max(self.data['freq'] / 1000.0)
+
+        self.logger.write(f"vmin=%{vmin} vmax={vmax} tmin={tmin} tmax={tmax} fmin={fmin} fmax={fmax}")
+        if vmin is None or vmax is None:
+            vmin = -100
+            vmax = -50
+            c_idx = self.data['data']['spec'] > -200.0
+            if np.sum(c_idx) > 100:
+                data_mean = np.mean(self.data['data']['spec'][c_idx])
+                data_std = np.std(self.data['data']['spec'][c_idx])
+                vmin = data_mean - 2.0 * data_std
+                vmax = data_mean + 4.0 * data_std
+        plt.figure(figsize=(10, 20))
+        plt.imshow(self.data['data']['spec'],
+                   origin='lower',
+                   aspect='auto',
+                   interpolation='None',
+                   extent=[fmin, fmax, tmin, tmax],
+                   vmin=vmin,
+                   vmax=vmax,
+                   cmap='Greens') # 'viridis', 'plasma', 'inferno', 'magma', 'cividis'
+                                  # also, see https://matplotlib.org/stable/tutorials/colors/colormaps.html
+        plt.xlabel('Frequency (kHz)')
+        plt.ylabel('Time (seconds)')
+        fig = plt.colorbar(aspect=50)
+        fig.set_label('Power (dB)')
+        plt.savefig(figure_path, bbox_inches='tight')
+        plt.close()
+
+    def _read_waterfall(self, datafile_path):
+        """
+        Read waterfall data file
+
+        :param datafile_path: Path to data file
+        :type datafile_path: str
+        :return: Waterfall data
+        :rtype: dict
+        """
+
+        datafile = open(datafile_path, mode='rb')
+
+        waterfall = {
+            'timestamp': np.fromfile(datafile, dtype='|S32', count=1)[0],
+            'nchan': np.fromfile(datafile, dtype='>i4', count=1)[0],
+            'samp_rate': np.fromfile(datafile, dtype='>i4', count=1)[0],
+            'nfft_per_row': np.fromfile(datafile, dtype='>i4', count=1)[0],
+            'center_freq': np.fromfile(datafile, dtype='>f4', count=1)[0],
+            'endianess': np.fromfile(datafile, dtype='>i4', count=1)[0]
+        }
+        self.logger.write("Waterfall details: " + repr(waterfall) + "\n")
+        data_dtypes = np.dtype([('tabs', 'int64'), ('spec', 'float32', (waterfall['nchan'], ))])
+        waterfall['data'] = np.fromfile(datafile, dtype=data_dtypes)
+        if waterfall['data'].size == 0:
+            raise EOFError
+
+        datafile.close()
+
+        return waterfall
+
+
+    def _compress_waterfall(self, waterfall):
+        """
+        Compress spectra of waterfall
+
+        :param waterfall: Watefall data
+        :type waterfall: dict
+        :return: Compressed spectra
+        :rtype: dict
+        """
+        spec = waterfall['data']['spec']
+        std = np.std(spec, axis=0)
+        offset = np.mean(spec, axis=0) + OFFSET_IN_STDS * std
+        scale = SCALE_IN_STDS * std / 255.0
+        values = np.clip((spec - offset) / scale, 0.0, 255.0).astype('uint8')
+
+        return {'offset': offset, 'scale': scale, 'values': values}
+
+
+    def _get_waterfall(self, datafile_path):
+        """
+        Get waterfall data
+
+        :param datafile_path: Path to data file
+        :type datafile_path: str_array
+        :return: Waterfall data including compressed data
+        :rtype: dict
+        """
+        waterfall = self._read_waterfall(datafile_path)
+
+        nint = waterfall['data']['spec'].shape[0]
+        waterfall['trel'] = np.arange(nint) * waterfall['nfft_per_row'] * waterfall['nchan'] / float(waterfall['samp_rate'])
+        waterfall['freq'] = np.linspace(-0.5 * waterfall['samp_rate'],
+                                        0.5 * waterfall['samp_rate'],
+                                        waterfall['nchan'],
+                                        endpoint=False)
+        waterfall['compressed'] = self._compress_waterfall(waterfall)
+
+        return waterfall
+
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage: waterfall.py waterfall.dat [waterfall.png]")
+        sys.exit(-1)
+
+    infile = sys.argv[1]
+    if len(sys.argv) >= 3:
+        outfile = sys.argv[2]
+    else:
+        outfile = sys.argv[1]
+        outfile = outfile[:outfile.rfind(".")]
+        outfile += ".png"
+
+    print("infile=%s outfile=%s" % (infile, outfile))
+    w = Waterfall(infile)
+    w.plot(outfile)

--- a/station/waterfall.py
+++ b/station/waterfall.py
@@ -39,7 +39,6 @@ class Waterfall():
         fmin = np.min(self.data['freq'] / 1000.0)
         fmax = np.max(self.data['freq'] / 1000.0)
 
-        self.logger.write(f"vmin=%{vmin} vmax={vmax} tmin={tmin} tmax={tmax} fmin={fmin} fmax={fmax}")
         if vmin is None or vmax is None:
             vmin = -100
             vmax = -50
@@ -76,23 +75,27 @@ class Waterfall():
         :rtype: dict
         """
 
-        datafile = open(datafile_path, mode='rb')
+        waterfall = {}
 
-        waterfall = {
-            'timestamp': np.fromfile(datafile, dtype='|S32', count=1)[0],
-            'nchan': np.fromfile(datafile, dtype='>i4', count=1)[0],
-            'samp_rate': np.fromfile(datafile, dtype='>i4', count=1)[0],
-            'nfft_per_row': np.fromfile(datafile, dtype='>i4', count=1)[0],
-            'center_freq': np.fromfile(datafile, dtype='>f4', count=1)[0],
-            'endianess': np.fromfile(datafile, dtype='>i4', count=1)[0]
-        }
-        self.logger.write("Waterfall details: " + repr(waterfall) + "\n")
-        data_dtypes = np.dtype([('tabs', 'int64'), ('spec', 'float32', (waterfall['nchan'], ))])
-        waterfall['data'] = np.fromfile(datafile, dtype=data_dtypes)
-        if waterfall['data'].size == 0:
-            raise EOFError
+        with open(datafile_path, mode='rb') as datafile:
 
-        datafile.close()
+            waterfall = {
+                'timestamp': np.fromfile(datafile, dtype='|S32', count=1)[0],
+                'nchan': np.fromfile(datafile, dtype='>i4', count=1)[0],
+                'samp_rate': np.fromfile(datafile, dtype='>i4', count=1)[0],
+                'nfft_per_row': np.fromfile(datafile, dtype='>i4', count=1)[0],
+                'center_freq': np.fromfile(datafile, dtype='>f4', count=1)[0],
+                'endianess': np.fromfile(datafile, dtype='>i4', count=1)[0]
+            }
+
+            # Let's disable the logging for now.
+            # self.logger.write("Waterfall details: " + repr(waterfall) + "\n")
+            data_dtypes = np.dtype([('tabs', 'int64'), ('spec', 'float32', (waterfall['nchan'], ))])
+            waterfall['data'] = np.fromfile(datafile, dtype=data_dtypes)
+            if waterfall['data'].size == 0:
+                raise EOFError
+
+            datafile.close()
 
         return waterfall
 
@@ -151,6 +154,5 @@ if __name__ == '__main__':
         outfile = outfile[:outfile.rfind(".")]
         outfile += ".png"
 
-    print("infile=%s outfile=%s" % (infile, outfile))
     w = Waterfall(infile)
     w.plot(outfile)


### PR DESCRIPTION
The following PR introduces a bridge between Svarog and Satnogs. The whole Svarog infrastructure (station framework, cli, recipes, etc.) remains in place. There is a new Svarog recipe that calls `satnogs_noaa_apt_decoder.py` script. That script is generated by GNU Radio, when loading `noaa_apt_decoder.grc`. This is a bit complicated to set up, but has tons of advantages:

- Provides GNU Radio flexibility. Anything is possible there (doppler correction, waterfall, adjustments, advanced processing etc.)
- Uses Soapy component, which supports ALL available SDR hardware on market (this was tested on AirSpy)
- This does not replace the existing `noaa_apt` recipe, but rather provide an alternative `noaa_apt_gr`. It is possible to switch back and forth between then to do comparison, experiments etc.

This approach, if accepted, should address #39 (SoapySDR integration), #10 (GNU Radio integration), and would make #12 (Doppler correction) much easier to do and #4 (upgrade to noaa-apt 1.3.0) less urgent.

This is not a complete solution, just a step in what I think is the right direction. There are many more steps missing:
- the installation is currently manual
- there are no unit-tests
- the waterfall.png is generated, but the upload doesn't work
- ~~there is no rating generated (that's essential for making comparisons between different radio settings)~~