### PR TITLE
Handle floating images in analog rating

### DIFF
--- a/station/quality_ratings/analog.py
+++ b/station/quality_ratings/analog.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from analog_noise_estimator import estimate as estimate_analog_noise
 
 
@@ -5,4 +7,8 @@ def rate(img):
     '''Uses noise estimation based on Gauss distribution. Only for analog
        noise in form similar to "groats" in old TV. Supports only 1D (grayscale)
        images.'''
+    # Analog noise estimator requires image in range 0-255. If image is loading as
+    # floating-point array (range 0-1) then it scales the values.
+    if img.max() <= 1.0 and np.issubdtype(img.dtype, np.floating):
+       img = img * 255 
     return 1.0 - estimate_analog_noise(img)

--- a/station/quality_ratings/analog.py
+++ b/station/quality_ratings/analog.py
@@ -7,8 +7,8 @@ def rate(img):
     '''Uses noise estimation based on Gauss distribution. Only for analog
        noise in form similar to "groats" in old TV. Supports only 1D (grayscale)
        images.'''
-    # Analog noise estimator requires image in range 0-255. If image is loading as
-    # floating-point array (range 0-1) then it scales the values.
+    # Analog noise estimator requires image in range 0-255. If the image is loaded as
+    # floating-point array (range 0.0-1.0), then the samples are scaled to 0.0-255.0 range.
     if img.max() <= 1.0 and np.issubdtype(img.dtype, np.floating):
        img = img * 255 
     return 1.0 - estimate_analog_noise(img)

--- a/station/tests/test_quality_ratings.py
+++ b/station/tests/test_quality_ratings.py
@@ -33,6 +33,27 @@ class TestQualityRatings(unittest.TestCase):
         rating = rate(img)
         self.assertAlmostEqual(0.5, rating, 1)
 
+    def test_analog_rating_on_gaussian_noise_small_sigma_floating_img(self):
+        img = np.random.normal(scale=1, size=(1000, 1000))
+        img = img.astype(float) / 255.
+        rate = quality_ratings.get_rate_by_name("analog")
+        rating = rate(img)
+        self.assertAlmostEqual(1.0, rating, 2)
+
+    def test_analog_rating_on_gaussian_noise_big_sigma_floating_img(self):
+        img = np.random.normal(scale=20, size=(1000, 1000))
+        img = img.astype(float) / 255.
+        rate = quality_ratings.get_rate_by_name("analog")
+        rating = rate(img)
+        self.assertAlmostEqual(0.0, rating, 2)
+
+    def test_analog_rating_on_gaussian_noise_medium_sigma_floating_img(self):
+        img = np.random.normal(scale=12.7, size=(1000, 1000))
+        img = img.astype(float) / 255.
+        rate = quality_ratings.get_rate_by_name("analog")
+        rating = rate(img)
+        self.assertAlmostEqual(0.5, rating, 1)
+
     def test_analog_rating_on_blank(self):
         '''Image doesn't contain any noise - good quality'''
         img = np.zeros((1000, 1000))
@@ -89,3 +110,4 @@ class TestQualityRatings(unittest.TestCase):
         rate = quality_ratings.get_rate_by_name("digital")
         rating = rate(img)
         self.assertAlmostEqual(0.75, rating, 3)
+


### PR DESCRIPTION
The analog noise estimator was designed using OpenCV. OpenCV loads an image as uint8 data type (values are integers in range 0-255). But the station we use Matplotlib to read the images. Matplotlib loads an image as float32 data type (values are floating-point numbers in range 0-1).

Now, the analog rating detects data type and scale data if needed.

It fixes a problem from #55 .