### PR TITLE
Fix for ratings calculation (#72)

### DIFF
--- a/station/quality_ratings/analog.py
+++ b/station/quality_ratings/analog.py
@@ -2,13 +2,27 @@ import numpy as np
 
 from analog_noise_estimator import estimate as estimate_analog_noise
 
-
 def rate(img):
     '''Uses noise estimation based on Gauss distribution. Only for analog
-       noise in form similar to "groats" in old TV. Supports only 1D (grayscale)
-       images.'''
+       noise in form similar to "groats" in old TV.
+
+       Supports both 1D (grayscale) and RGBA images.'''
+
+    if len(img.shape) == 3:
+        # Magic happens here. If the image is read as RGBA, then it's really a 3D array
+        # (each pixel is an 4 element array of values for each channel).
+        # Since the alpha channel is always 1.0, we need to use offset sum, which starts
+        # with a value of -1.0. The values are in 0.0..1.0 range, so need to convert to
+        # 0..255 range and then divide by 3, because we summed 3 channels (RGB).
+        tmp = img.sum(axis=2, initial=-1.0)*255/3
+
+        # The values are almost fine, except some sums are almost correct (e.g. 43.99995).
+        # To address those, we'll be adding 0.5 to each value, which will then be trucnated.
+        img = np.array(tmp+0.5, dtype=np.uint8)
+
     # Analog noise estimator requires image in range 0-255. If the image is loaded as
     # floating-point array (range 0.0-1.0), then the samples are scaled to 0.0-255.0 range.
     if img.max() <= 1.0 and np.issubdtype(img.dtype, np.floating):
-       img = img * 255 
+       img = img * 255
+
     return 1.0 - estimate_analog_noise(img)

--- a/station/tests/test_receiver.py
+++ b/station/tests/test_receiver.py
@@ -8,7 +8,7 @@ class TestReceiverRatings(unittest.TestCase):
     def setUp(self):
         data_directory = os.path.join(os.path.dirname(__file__), "data")
         self.rgb_path = os.path.join(data_directory, "rgb-image.png")
-        self.gray_path = os.path.join(data_directory, "gray-image.png") 
+        self.gray_path = os.path.join(data_directory, "gray-image.png")
 
     def test_rating_for_single_layer_product(self):
         rating = receiver.get_rating_for_product(self.gray_path, "analog")
@@ -38,7 +38,8 @@ class TestReceiverRatings(unittest.TestCase):
 
     def test_single_layer_rating_called_with_multi_layer_product(self):
         rating = receiver.get_rating_for_product(self.rgb_path, "analog")
-        self.assertIsNone(rating)
+        # with the recent updates, the rating now works for RGB images
+        self.assertIsNotNone(rating)
 
     def test_multi_layer_rating_called_with_single_layer_product(self):
         rating = receiver.get_rating_for_product(self.gray_path, "digital")


### PR DESCRIPTION
Problem details available in #72.

This fix effectively adds support for RGBA images, which are converted to grayscale on the fly. This is currently being tested, thus the draft status.