### PR TITLE
Gallery visual tweaks

### DIFF
--- a/server/app/static/svarog.css
+++ b/server/app/static/svarog.css
@@ -123,3 +123,7 @@ dd {
 #gallery img+img {
     margin: 1rem;
 }
+
+.viewer-footer {
+    background-color: rgba(0,0,0,.5);
+}

--- a/server/templates/station.html
+++ b/server/templates/station.html
@@ -37,7 +37,7 @@
         </ul>
     </p>
     <p>
-        <span class="section-title">About the station</span>: {{ station.descr }}
+        <span class="section-title">About the station</span>: {{ station.descr|safe }}
     </p>
     <p>
         <span class="section-title">Current configuration:</span>
@@ -53,7 +53,7 @@
     {% if files is defined %}
     <div id="gallery">
         {% for f in files %}
-        <img src='/data/stations/{{ station.station_id }}/{{ f.filename }}' alt="{{ f.descr }}">
+        <img src='/data/stations/{{ station.station_id }}/{{ f.filename }}' alt="{{ f.descr|safe }}">
         {% endfor %}
     </div>
     {% endif %}


### PR DESCRIPTION
Two very minor tweaks:

- the image descriptions in the gallery now are on dark background, making them more readable
- the image and station descriptions are marked as safe, enabling putting HTML formatting (e.g. links in them)

The second change is considered safe as there is no way for external users to put the descriptions in the database.