### PR TITLE
Local observations list implemented

### DIFF
--- a/server/app/controllers/receive.py
+++ b/server/app/controllers/receive.py
@@ -213,7 +213,12 @@ def receive(station_id: str, args: RequestArguments):
 
     # Make sure to return the observation id to the station. This may be useful if the station wants
     # to update the observation in some way (send additional info or perhaps decide to delete it in the future).
-    return 'Observation %d received.' % obs_id, 201
+    # Extra parameters may be added in the future.
+    status = {
+        "status": "success",
+        "obs_id": obs_id
+    }
+    return status, 201
 
 
 def make_charts(observation: Observation, station: Station,

--- a/server/app/controllers/receive.py
+++ b/server/app/controllers/receive.py
@@ -213,7 +213,7 @@ def receive(station_id: str, args: RequestArguments):
 
     # Make sure to return the observation id to the station. This may be useful if the station wants
     # to update the observation in some way (send additional info or perhaps decide to delete it in the future).
-    return 'Observation %d received.' % obs_id, 204
+    return 'Observation %d received.' % obs_id, 201
 
 
 def make_charts(observation: Observation, station: Station,

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -28,7 +28,7 @@ click==8.1.7
     # via flask
 contourpy==1.1.0
     # via matplotlib
-cryptography==41.0.3
+cryptography==41.0.4
     # via secretstorage
 cycler==0.11.0
     # via matplotlib

--- a/server/tests/test_web_interface.py
+++ b/server/tests/test_web_interface.py
@@ -105,7 +105,7 @@ class BasicTests(unittest.TestCase):
             'Authorization': header_value
         }
         response = self.app.post('/receive', data=data, headers=headers)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 201)
 
         def file_count(dir_): return len(
             [f for f in os.listdir(dir_)

--- a/station/cli.py
+++ b/station/cli.py
@@ -465,6 +465,6 @@ elif command == "obs":
         print("No obsdir defined in config file. Please use `station config global --directory <dir>` to set it.")
         sys.exit(1)
 
-    obs_list(obsdir = config["obsdir"], clean = args.clean)
+    obs_list(obsdir=config["obsdir"], clean=args.clean)
 else:
     parser.print_help()

--- a/station/cli.py
+++ b/station/cli.py
@@ -24,6 +24,7 @@ from utils.functional import first
 from utils.globalvars import APP_NAME, LOG_FILE, COMMENT_PASS_TAG, COMMENT_PLAN_TAG, COMMENT_UPDATE_TAG, CONFIG_PATH
 from utils.dates import from_iso_format
 from utils.cron import get_planner_command, get_receiver_command, open_crontab
+from utils.observations import obs_list
 from crontab import CronItem
 from orbit_predictor.locations import Location
 from recipes.factory import get_recipe_names
@@ -217,6 +218,8 @@ server_config_parser.add_argument("-s", "--secret", type=hex_bytes, help="HMAC s
 logging_parser = config_subparsers.add_parser("logging", help="Station logging configuration")
 logging_parser.add_argument("--level", choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
                             help="Specify the logging level (DEBUG, INFO, WARNING, ERROR, or CRITICAL)")
+
+obs_parser = subparsers.add_parser("obs", help="Local observations management")
 
 metadata_parser = subparsers.add_parser("metadata", help="Displays metadata")
 
@@ -453,6 +456,14 @@ elif command == "metadata":
     print(f"Metadata stored in {m.filename}. Please tweak its content as needed.")
     print("Currently defined metadata:")
     print(m.getString())
+elif command == "obs":
+    print("Loading config file %s" % CONFIG_PATH)
+    config = open_config()
+    obsdir = ""
+    if "obsdir" not in config.keys():
+        print("No obsdir defined in config file. Please use `station config global --directory <dir>` to set it.")
+        sys.exit(1)
 
+    obs_list(obsdir = config["obsdir"])
 else:
     parser.print_help()

--- a/station/cli.py
+++ b/station/cli.py
@@ -220,6 +220,7 @@ logging_parser.add_argument("--level", choices=("DEBUG", "INFO", "WARNING", "ERR
                             help="Specify the logging level (DEBUG, INFO, WARNING, ERROR, or CRITICAL)")
 
 obs_parser = subparsers.add_parser("obs", help="Local observations management")
+obs_parser.add_argument("--clean", action="store_true", default=False, help="Clean useless observations (default: %(default)s)")
 
 metadata_parser = subparsers.add_parser("metadata", help="Displays metadata")
 
@@ -464,6 +465,6 @@ elif command == "obs":
         print("No obsdir defined in config file. Please use `station config global --directory <dir>` to set it.")
         sys.exit(1)
 
-    obs_list(obsdir = config["obsdir"])
+    obs_list(obsdir = config["obsdir"], clean = args.clean)
 else:
     parser.print_help()

--- a/station/cli.py
+++ b/station/cli.py
@@ -221,6 +221,7 @@ logging_parser.add_argument("--level", choices=("DEBUG", "INFO", "WARNING", "ERR
 
 obs_parser = subparsers.add_parser("obs", help="Local observations management")
 obs_parser.add_argument("--clean", action="store_true", default=False, help="Clean useless observations (default: %(default)s)")
+obs_parser.add_argument("--del-uploaded", action="store_true", default=False, help="Deletes observations that were uploaded (default: %(default)s)")
 
 metadata_parser = subparsers.add_parser("metadata", help="Displays metadata")
 
@@ -465,6 +466,6 @@ elif command == "obs":
         print("No obsdir defined in config file. Please use `station config global --directory <dir>` to set it.")
         sys.exit(1)
 
-    obs_list(obsdir=config["obsdir"], clean=args.clean)
+    obs_list(obsdir=config["obsdir"], clean=args.clean, del_uploaded=args.del_uploaded)
 else:
     parser.print_help()

--- a/station/metadata.py
+++ b/station/metadata.py
@@ -45,9 +45,11 @@ class Metadata:
         self.addDefaults()
         self.writeFile()
 
-    def writeFile(self):
+    def writeFile(self, filename=None):
         """Writes content of the metadata to disk."""
-        with open(self.filename, 'w') as outfile:
+        if not filename:
+            filename = self.filename
+        with open(filename, 'w') as outfile:
             outfile.write(self.getString())
 
     def getAll(self) -> Dict:

--- a/station/receiver.py
+++ b/station/receiver.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import sys
 import typing
-import json
 
 from matplotlib.pyplot import imread
 
@@ -84,8 +83,8 @@ def cmd():
 
     try:
         results, dir, metadata = factory.execute_recipe(satellite, los_datetime)
-    except:
-        logging.error("ERROR: Recipe execution failed, exception:", exc_info=True)
+    except Exception as e:
+        logging.error(f"ERROR: Recipe execution failed, exception: {e}")
         return
 
     # We're entirely sure the recipe is honest and reported only files that were actually created *cough*.

--- a/station/receiver.py
+++ b/station/receiver.py
@@ -131,7 +131,7 @@ def cmd():
             rating = get_rating_for_product(product[1], satellite.get("rate"))
             logging.info("Product %s got rating %s" % (product[1], rating))
             # TODO: Submit ALL products and logs
-            logging.warning(f"TODO: signal submission not implemented yet")
+            logging.warning("TODO: signal submission not implemented yet")
             files = [product[1]]
             submit_observation(
                 SubmitRequestData(

--- a/station/receiver.py
+++ b/station/receiver.py
@@ -84,7 +84,7 @@ def cmd():
     try:
         results, dir, metadata = factory.execute_recipe(satellite, los_datetime)
     except Exception as e:
-        logging.error(f"ERROR: Recipe execution failed, exception: {e}")
+        logging.error(f"ERROR: Recipe execution failed, exception: {e}, {str(e)}")
         return
 
     # We're entirely sure the recipe is honest and reported only files that were actually created *cough*.
@@ -131,7 +131,7 @@ def cmd():
             rating = get_rating_for_product(product[1], satellite.get("rate"))
             logging.info("Product %s got rating %s" % (product[1], rating))
             # TODO: Submit ALL products and logs
-            logging.warning("TODO: signal submission not implemented yet (%s)" % signal)
+            logging.warning(f"TODO: signal submission not implemented yet")
             files = [product[1]]
             submit_observation(
                 SubmitRequestData(

--- a/station/receiver.py
+++ b/station/receiver.py
@@ -86,6 +86,10 @@ def cmd():
     m = Metadata()
     for x in metadata:
         m.set(x, metadata[x])
+    # Write metadata to local file
+    metadata_file = os.path.join(dir, "metadata.json")
+    m.writeFile(metadata_file)
+    logging.info(f"INFO: metadata written to {metadata_file}.")
 
     if should_submit:
         logging.info("Submitting results")

--- a/station/receiver.py
+++ b/station/receiver.py
@@ -107,8 +107,11 @@ def cmd():
     save_mode = satellite["save_to_disk"]
     should_submit = satellite["submit"]
 
-    signal = first(results, lambda r: r[0] == "SIGNAL")
     products = filter(lambda r: r[0] == "PRODUCT", results)
+
+    # We could extract the signal file and log file here, but we don't need them for now.
+    # signal = first(results, lambda r: r[0] == "SIGNAL")
+    # log = first(results, lambda r: r[0] == "LOG")
 
     # Use the metadata stored in file, but supplement it with details returned by the recipe
     m = Metadata()

--- a/station/recipes/helpers.py
+++ b/station/recipes/helpers.py
@@ -28,7 +28,7 @@ def set_sh_defaults(f):
     '''
     @wraps(f)
     def inner(working_dir, *args, **kwargs):
-        sh2 = sh(_cwd=working_dir)
+        sh2 = sh.bake(_cwd=working_dir)
         kwargs["sh"] = sh2
         return f(working_dir, *args, **kwargs)
     return inner

--- a/station/recipes/meteor_qpsk.py
+++ b/station/recipes/meteor_qpsk.py
@@ -1,17 +1,26 @@
 from contextlib import suppress
-from datetime import timedelta
+from datetime import timedelta, datetime
 import os.path
 import signal
 
 import sh
+import logging
 
 from recipes.helpers import set_sh_defaults
 
+logging.basicConfig(level=logging.INFO)
 
 @set_sh_defaults
 def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
     signal_path = os.path.join(working_dir, "signal.wav")
     product_path = os.path.join(working_dir, "product.png")
+    raw_path = os.path.join(working_dir, "signal.raw")
+    log_path = os.path.join(working_dir, "session.log")
+
+    print(f"Writing log to {log_path}")
+    logfile = open(log_path, "w")
+    logfile.write(f"meteor-qpsk recipe, writing to {working_dir}, capturing freq {frequency}, duration {duration}\n")
+    logfile.flush()
 
     normalized_signal_path = os.path.join(working_dir, "normalized_signal.wav")
     qpsk_path = os.path.join(working_dir, "qpsk")
@@ -21,7 +30,11 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
     product_raw_path = product_raw_prefix_path + ".bmp"
 
     # Record signal
-    fm_proc = sh.rtl_fm(
+
+    logfile.write(f"{str(datetime.now())} --- rtl_fm log ---\n")
+    logfile.flush()
+    with suppress(sh.TimeoutException):
+        fm_proc = sh.rtl_fm(
         # Modulation raw
         "-M", "raw",
         # Set frequency (in Hz, e.g. 137MHz)
@@ -32,62 +45,78 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
         "-s", 48000,
         # Almost maximal possible value. Probably is wrong for other SDR then rtl-sdr
         "-g", 48,
-        # Copy-paste from suspects www
+        # Copy-paste from suspicious www
         "-p", 1,
+        raw_path,
         _timeout=duration.total_seconds(),
-        _timeout_signal=signal.SIGTERM,
-        _piped=True
-    )
+        _timeout_signal=signal.SIGKILL,
+        _err=logfile,
+        _bg_exc=False
+        )
 
-    with suppress(sh.TimeoutException):
-        sh.sox(fm_proc,
-               # Type of input
-               "-t", "raw",
-               "-r", "288k",
-               # Channels - 2 - stereo
-               "-c", 2,
-               # Sample size
-               "-b", 16,
-               # Signed integer encoding
-               "-e", "s",
-               # Verbosity level (0 - silence, 1 - failure messages, 2 - warnings, 3 - processing phases, 4 - debug)
-               "-V3",
-               # Read from stdin (from pipe)
-               "-",
-               # Type of output
-               "-t", "wav",
-               signal_path,
-               # Resampling rate
-               "rate", "96k"
-               )
+    logfile.write(f"{str(datetime.now())} --- sox (step 1, convert) log ---\n")
+    logfile.flush()
+    sox_proc = sh.sox(
+        # Type of input
+        "-t", "raw",
+        "-r", "288k",
+        # Channels - 2 - stereo
+        "-c", 2,
+        # Sample size
+        "-b", 16,
+        # Signed integer encoding
+        "-e", "s",
+        # Verbosity level (0 - silence, 1 - failure messages, 2 - warnings, 3 - processing phases, 4 - debug)
+        "-V3",
+        # Read from stdin (from pipe)
+        raw_path,
+        # Type of output
+        "-t", "wav",
+        signal_path,
+        # Resampling rate
+        "rate", "96k",
+        _out=logfile
+        )
+
 
     # Normalize signal
+    logfile.write(f"{str(datetime.now())} --- sox (step 2, normalize signal) log ---\n")
+    logfile.flush()
     sh.sox(
         signal_path,
         normalized_signal_path,
         # Normalize to 0dBfs
-        "gain", "-n"
+        "gain", "-n",
+        _out=logfile
     )
 
     # Demodulating
+    logfile.write(f"{str(datetime.now())} --- meteor_demod log ---\n")
+    logfile.flush()
     sh.meteor_demod(
         sh.yes(_piped=True),
         "-o", qpsk_path,
-        "-B", normalized_signal_path
+        "-B", normalized_signal_path,
+        _out=logfile
     )
 
     # Keep original file timestamp
     sh.touch("-r", signal_path, qpsk_path)
 
     # Decode QPSK
+    logfile.write(f"{str(datetime.now())} --- medet (decode QPSK) log ---\n")
+    logfile.flush()
     sh.medet(
         qpsk_path,
         dump_prefix_path,
         # Make doceded dump (fastest)
-        "-cd"
+        "-cd",
+        _out=logfile
     )
 
     # Generate images
+    logfile.write(f"{str(datetime.now())} --- medet (generate images) log ---\n")
+    logfile.flush()
     sh.medet(dump_path, product_raw_prefix_path,
              # APID for red
              "-r", 66,
@@ -96,13 +125,21 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
              # APID for blue
              "-b", 64,
              # Use dump
-             "-d"
-             )
+             "-d",
+             _out=logfile
+            )
 
     # Convert to PNG
-    sh.convert(product_raw_path, product_path)
+    logfile.write(f"{str(datetime.now())} --- convert product log ---\n")
+    logfile.flush()
+    sh.convert(product_raw_path, product_path, _out=logfile)
+
+    logfile.write(f"{str(datetime.now())} meteor_qpsk recipe complete.\n")
+    logfile.flush()
 
     return [
         ("SIGNAL", signal_path),
-        ("PRODUCT", product_path)
+        ("PRODUCT", product_path),
+        ("LOG", log_path),
+        ("RAW", raw_path)
     ]

--- a/station/recipes/meteor_qpsk.py
+++ b/station/recipes/meteor_qpsk.py
@@ -27,7 +27,7 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
         # Set frequency (in Hz, e.g. 137MHz)
         "-f", frequency,
         # Enable bias-T
-        "-T",
+        #"-T",
         # Specify sampling rate (e.g. 48000 Hz)
         "-s", 48000,
         # Almost maximal possible value. Probably is wrong for other SDR then rtl-sdr

--- a/station/recipes/meteor_qpsk.py
+++ b/station/recipes/meteor_qpsk.py
@@ -26,8 +26,8 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
         "-M", "raw",
         # Set frequency (in Hz, e.g. 137MHz)
         "-f", frequency,
-        # Enable bias-T
-        #"-T",
+        # Enable bias-T (disabled)
+        # "-T",
         # Specify sampling rate (e.g. 48000 Hz)
         "-s", 48000,
         # Almost maximal possible value. Probably is wrong for other SDR then rtl-sdr

--- a/station/recipes/noaa_apt.py
+++ b/station/recipes/noaa_apt.py
@@ -53,12 +53,14 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
                 _err=logfile
             )
             rtl_proc.send_signal(signal.SIGKILL)
+
         except sh.ErrorReturnCode_1 as e:
             # The rtl_fm command is undocumented wrt to exit codes. Reading the code, it could return 1
             # in multiple cases in rtlsdr_open().
             logfile.write(f"ERROR: rtl_fm failed with exit code 1, details: {e}\n")
 
     logfile.write("---sox log-------\n")
+    logfile.flush()
 
     # Run sox - this convert raw samples into audible WAV
     sh.sox(  # Type of input

--- a/station/recipes/noaa_apt.py
+++ b/station/recipes/noaa_apt.py
@@ -37,8 +37,8 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
             "-p", 1,
             # Higher quality downsampling - possible value 0 or 9. 9 is experimental.
             "-F", 9,
-            # Enable bias-T
-            #"-T",
+            # Enable bias-T (disabled)
+            # "-T",
             # How arctan is computed. We don't test other options.
             "-A", "fast",
             # dc blocking filter (?)

--- a/station/recipes/noaa_apt.py
+++ b/station/recipes/noaa_apt.py
@@ -27,7 +27,7 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
     # Run rtl_fm/rx_fm - this records the actual samples from the RTL device
     with suppress(sh.TimeoutException):
         try:
-            sh.rtl_fm(
+            rtl_proc = sh.rtl_fm(
                 # Specify frequency (in Hz, e.g. 137MHz)
                 "-f", frequency,
                 # Specify sampling rate (e.g. 48000 Hz)
@@ -47,11 +47,12 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
                 # Output to pipe, optional in this command
                 raw_path,
                 _timeout=duration.total_seconds(),
-                _timeout_signal=signal.SIGKILL,
+                _timeout_signal=signal.SIGHUP,
 
                 # rtl_fm and rx_fm both print messages on stderr
                 _err=logfile
             )
+            rtl_proc.send_signal(signal.SIGKILL)
         except sh.ErrorReturnCode_1 as e:
             # The rtl_fm command is undocumented wrt to exit codes. Reading the code, it could return 1
             # in multiple cases in rtlsdr_open().

--- a/station/recipes/noaa_apt.py
+++ b/station/recipes/noaa_apt.py
@@ -38,7 +38,7 @@ def execute(working_dir: str, frequency: str, duration: timedelta, sh=sh):
             # Higher quality downsampling - possible value 0 or 9. 9 is experimental.
             "-F", 9,
             # Enable bias-T
-            "-T",
+            #"-T",
             # How arctan is computed. We don't test other options.
             "-A", "fast",
             # dc blocking filter (?)

--- a/station/submitobs.py
+++ b/station/submitobs.py
@@ -156,7 +156,10 @@ def submit_observation(data: SubmitRequestData):
     try:
         resp = requests.post(url, form_data, headers=headers, files=files)
     except requests.exceptions.ConnectionError:
-        return f"Unable to connect to {url}, connection refused"
+        return {
+            "status-code": 0,
+            "response-text": f"Unable to connect to {url}, connection refused"
+        }
     if (resp.status_code >= 400):
         logging.warning("Response status: %d" % resp.status_code)
     else:
@@ -177,8 +180,6 @@ def submit_observation(data: SubmitRequestData):
         logging.debug("Response details: %s" % resp.text)
     else:
         logging.info(f"Upload successful: {resp.text}")
-
-    # write upload result to a file:
 
     # All seems to be OK
     return status
@@ -220,14 +221,6 @@ if __name__ == '__main__':
     status = submit_observation(
         SubmitRequestData(filename, sat_name, aos, tca, los, cfg, rating)
     )
-
-    if status:
-        logging.info(f"Upload result: {status}")
-        # write status to file
-        result_file = str(os.path.dirname(os.path.abspath(filename[0]))) + "/upload_result.json"
-        with open(result_file, "w") as f:
-            f.write(json.dumps(status, indent=4))
-            logging.info(f"Upload result stored in {result_file}")
 
     # Empty string means success, everything else is a failure
     sys.exit(0 if status["status-code"] in [201, 204] else 1)

--- a/station/submitobs.py
+++ b/station/submitobs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import datetime
 import os
 import requests
@@ -180,7 +180,7 @@ def submit_observation(data: SubmitRequestData):
 if __name__ == '__main__':
     if len(sys.argv) < 4:
         print("Not enough parameters. At least 3 are needed: "
-              "filename sat_name aos [tca] [los] [notes] [rating]")
+              "filename sat_name aos [tca] [los] [metadata.json] [rating(float)]")
         print("filename can be a single file or coma separated list (no spaces)")
         exit(1)
 

--- a/station/submitobs.py
+++ b/station/submitobs.py
@@ -225,7 +225,7 @@ if __name__ == '__main__':
         logging.info(f"Upload result: {status}")
         # write status to file
         result_file = str(os.path.dirname(os.path.abspath(filename[0]))) + "/upload_result.json"
-        with open(result_file , "w") as f:
+        with open(result_file, "w") as f:
             f.write(json.dumps(status, indent=4))
             logging.info(f"Upload result stored in {result_file}")
 

--- a/station/tests/test_cli.py
+++ b/station/tests/test_cli.py
@@ -102,14 +102,15 @@ class TestCli(unittest.TestCase):
     def test_cli_help(self):
         """Checks if help is printed and has reasonable information."""
 
-        exp = ["usage: svarog [-h] {clear,logs,plan,pass,config,metadata}",
+        exp = ["usage: svarog [-h] {clear,logs,plan,pass,config,obs,metadata}",
                "positional arguments:",
-               "{clear,logs,plan,pass,config,metadata}",
+               "{clear,logs,plan,pass,config,obs,metadata}",
                "clear               Clear all scheduled reception events",
                "logs                Show logs",
                "plan                Schedule planned reception events",
                "pass                Information about passes",
                "config              Configuration",
+               "obs                 Local observations management",
                "metadata            Displays metadata",
                "-h, --help            show this help message and exit"
                ]

--- a/station/utils/observations.py
+++ b/station/utils/observations.py
@@ -1,0 +1,65 @@
+
+from shutil import disk_usage
+from pathlib import Path
+import re
+from enum import Enum
+
+class ObservationStatus(Enum):
+    USELESS = 0 # Observation is useless (no useful data, just log)
+    UNKOWN = 1 # Unable to determine status
+    SUCCESS = 2 # Observation is successful, but was not uploaded
+    SUBMITTED = 3 # Was able to confirm that the observation was uploaded properly.
+
+def obs_list(obsdir: str):
+    obs_stats(obsdir)
+
+    dirs = sorted([d for d in Path(obsdir).glob('*') if d.is_dir()])
+    useless_cnt = 0
+    total_cnt = 0
+    unknown_cnt = 0
+    for d in dirs:
+        status = obs_determine_status(obsdir, d.name)
+        total_cnt += 1
+        if status == ObservationStatus.USELESS:
+            useless_cnt += 1
+        elif status == ObservationStatus.UNKOWN:
+            unknown_cnt += 1
+        obs_print_info(obsdir, d.name)
+
+    print(f"SUMMARY: {total_cnt} observations, {useless_cnt} useless, {unknown_cnt} unknown, {total_cnt - useless_cnt - unknown_cnt} useful.")
+
+def obs_print_info(obsdir: str, obsname: str):
+    du = sum(file.stat().st_size for file in Path(obsdir + "/" + obsname).rglob('*'))
+
+    regex = re.compile(r"([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4})-([a-zA-Z-0-9_]+)")
+    match = regex.match(obsname)
+    date = ""
+    satname = ""
+    if match:
+        date = match.group(1)
+        satname = match.group(2)
+
+    status = obs_determine_status(obsdir, obsname)
+    print(f"Observation {obsname} (date: {date}, sat: {satname}) uses {sizeof_fmt(du)} of disk space, status: {status}.")
+
+def obs_determine_status(obsdir: str, obsname: str) -> ObservationStatus:
+
+    # Test 1: check if there is only a session.log file. If there is, there's no data, so it's a failed observation.
+    files = [f for f in Path(obsdir + "/" + obsname).glob('*') if f.is_file()]
+    if len(files) == 1 and files[0].name == "session.log":
+        return ObservationStatus.USELESS
+    if len(files) == 1 and files[0].name == "signal.wav" and files[0].stat().st_size < 1024:
+        return ObservationStatus.USELESS
+
+    return ObservationStatus.UNKOWN
+
+def sizeof_fmt(num, suffix="B"):
+    for unit in ("", "K", "M", "G", "Ti", "Pi", "Ei", "Zi"):
+        if abs(num) < 1000.0:
+            return f"{num:3.1f}{unit}{suffix}"
+        num /= 1000.0
+    return f"{num:.1f}Yi{suffix}"
+
+def obs_stats(obsdir: str):
+    du = sum(file.stat().st_size for file in Path(obsdir).rglob('*'))
+    print(f"Observation directory: {obsdir} uses {sizeof_fmt(du)} of disk space.")

--- a/station/utils/observations.py
+++ b/station/utils/observations.py
@@ -103,7 +103,7 @@ def obs_determine_status(obsdir: str, obsname: str) -> ObservationStatus:
 
     # Test 1: If there's a upload status file, it's a successful, uploaded observation.
     for file in files:
-        if file.name == "upload_result.json":
+        if file.name == "uploaded.json":
             return ObservationStatus.SUBMITTED
 
     # Test 2: check if there is only a session.log file. If there is, there's no data, so it's a failed observation.

--- a/station/utils/observations.py
+++ b/station/utils/observations.py
@@ -1,14 +1,15 @@
 
-from shutil import disk_usage
 from pathlib import Path
 import re
 from enum import Enum
 
+
 class ObservationStatus(Enum):
-    USELESS = 0 # Observation is useless (no useful data, just log)
-    UNKOWN = 1 # Unable to determine status
-    SUCCESS = 2 # Observation is successful, but was not uploaded
-    SUBMITTED = 3 # Was able to confirm that the observation was uploaded properly.
+    USELESS = 0  # Observation is useless (no useful data, just log)
+    UNKOWN = 1  # Unable to determine status
+    SUCCESS = 2  # Observation is successful, but was not uploaded
+    SUBMITTED = 3  # Was able to confirm that the observation was uploaded properly.
+
 
 def obs_del(obsdir: str, obsname: str):
     print(f"Deleting observation {obsname}...")
@@ -25,6 +26,7 @@ def obs_del(obsdir: str, obsname: str):
     for f in obsdir.glob('*'):
         f.unlink()
     obsdir.rmdir()
+
 
 def obs_list(obsdir: str, clean: bool = False):
     obs_stats(obsdir)
@@ -47,6 +49,7 @@ def obs_list(obsdir: str, clean: bool = False):
 
     print(f"SUMMARY: {total_cnt} observations, {useless_cnt} useless, {unknown_cnt} unknown, {total_cnt - useless_cnt - unknown_cnt} useful.")
 
+
 def obs_print_info(obsdir: str, obsname: str):
     du = sum(file.stat().st_size for file in Path(obsdir + "/" + obsname).rglob('*'))
 
@@ -61,6 +64,7 @@ def obs_print_info(obsdir: str, obsname: str):
     status = obs_determine_status(obsdir, obsname)
     print(f"Observation {obsname} (date: {date}, sat: {satname}) uses {sizeof_fmt(du)} of disk space, status: {status}.")
 
+
 def obs_determine_status(obsdir: str, obsname: str) -> ObservationStatus:
 
     # Test 1: check if there is only a session.log file. If there is, there's no data, so it's a failed observation.
@@ -72,12 +76,14 @@ def obs_determine_status(obsdir: str, obsname: str) -> ObservationStatus:
 
     return ObservationStatus.UNKOWN
 
+
 def sizeof_fmt(num, suffix="B"):
     for unit in ("", "K", "M", "G", "Ti", "Pi", "Ei", "Zi"):
         if abs(num) < 1000.0:
             return f"{num:3.1f}{unit}{suffix}"
         num /= 1000.0
     return f"{num:.1f}Yi{suffix}"
+
 
 def obs_stats(obsdir: str):
     du = sum(file.stat().st_size for file in Path(obsdir).rglob('*'))

--- a/station/utils/observations.py
+++ b/station/utils/observations.py
@@ -10,7 +10,23 @@ class ObservationStatus(Enum):
     SUCCESS = 2 # Observation is successful, but was not uploaded
     SUBMITTED = 3 # Was able to confirm that the observation was uploaded properly.
 
-def obs_list(obsdir: str):
+def obs_del(obsdir: str, obsname: str):
+    print(f"Deleting observation {obsname}...")
+    obsdir = Path(obsdir)
+    obsname = Path(obsname)
+    fullpath = obsdir / obsname
+    if not obsdir.is_dir():
+        print(f"Observation directory {obsdir} does not exist!")
+        return
+    if not fullpath.is_dir():
+        print(f"Observation {fullpath} does not exist!")
+        return
+    obsdir = obsdir / obsname
+    for f in obsdir.glob('*'):
+        f.unlink()
+    obsdir.rmdir()
+
+def obs_list(obsdir: str, clean: bool = False):
     obs_stats(obsdir)
 
     dirs = sorted([d for d in Path(obsdir).glob('*') if d.is_dir()])
@@ -25,6 +41,9 @@ def obs_list(obsdir: str):
         elif status == ObservationStatus.UNKOWN:
             unknown_cnt += 1
         obs_print_info(obsdir, d.name)
+        if clean and status == ObservationStatus.USELESS:
+            print(f"obsdir={obsdir} Deleting useless observation {d.name}...")
+            obs_del(obsdir, d.name)
 
     print(f"SUMMARY: {total_cnt} observations, {useless_cnt} useless, {unknown_cnt} unknown, {total_cnt - useless_cnt - unknown_cnt} useful.")
 

--- a/station/utils/observations.py
+++ b/station/utils/observations.py
@@ -53,6 +53,7 @@ def obs_list(obsdir: str, clean: bool = False, del_uploaded: bool = False):
     dirs = sorted([d for d in Path(obsdir).glob('*') if d.is_dir()])
     useless_cnt = 0
     submitted_cnt = 0
+    success_cnt = 0
     total_cnt = 0
     unknown_cnt = 0
     for d in dirs:
@@ -64,6 +65,8 @@ def obs_list(obsdir: str, clean: bool = False, del_uploaded: bool = False):
             unknown_cnt += 1
         elif status == ObservationStatus.SUBMITTED:
             submitted_cnt += 1
+        elif status == ObservationStatus.SUCCESS:
+            success_cnt += 1
         obs_print_info(obsdir, d.name)
         if clean and status == ObservationStatus.USELESS:
             print(f"obsdir={obsdir} Deleting useless observation {d.name}...")
@@ -75,7 +78,7 @@ def obs_list(obsdir: str, clean: bool = False, del_uploaded: bool = False):
             print(f"obsdir={obsdir} Deleting uploaded observation {d.name}...")
             obs_del(obsdir, d.name)
 
-    print(f"SUMMARY: {total_cnt} observations, {submitted_cnt} uploaded, {useless_cnt} useless, {unknown_cnt} unknown, {total_cnt - useless_cnt - unknown_cnt} useful.")
+    print(f"SUMMARY: {total_cnt} observations, {submitted_cnt} uploaded, {success_cnt} successful, {useless_cnt} useless, {unknown_cnt} unknown.")
 
 
 def obs_print_info(obsdir: str, obsname: str):
@@ -122,10 +125,10 @@ def obs_determine_status(obsdir: str, obsname: str) -> ObservationStatus:
 
     if found and file is not None:
         if file.stat().st_size < 1024:
-            print(f"Found a small png file {file}, assuming this is a failed observation.")
+            # Found a small png file {file}, assuming this is a failed observation.
             return ObservationStatus.USELESS
         else:
-            print(f"Found a large png file {file}, assuming this is a successful observation.")
+            # Found a large png file {file}, assuming this is a successful observation.
             return ObservationStatus.SUCCESS
 
     # Test 5: If there's a very small wav file, it's useless junk.

--- a/station/utils/observations.py
+++ b/station/utils/observations.py
@@ -29,6 +29,23 @@ def obs_del(obsdir: str, obsname: str):
     obsdir.rmdir()
 
 
+def obs_clean(obsdir: str, obsname: str):
+    """Removes obsolete files from good, successfull operation."""
+    obsdir = Path(obsdir + "/" + obsname)
+    files = obsdir.glob('*.png')
+
+    if list(files):
+        # Ok, there are PNG files, we can get rid of the .raw and .wav files.
+        wav_files = obsdir.glob('*.wav')
+        for file in wav_files:
+            print(f"PNG exists in this {str(obsdir)}, deleting {str(file)}")
+            file.unlink()
+        raw_files = obsdir.glob('*.raw')
+        for file in raw_files:
+            print(f"RAW exists in this {str(obsdir)}, deleting {str(file)}")
+            file.unlink()
+
+
 def obs_list(obsdir: str, clean: bool = False):
     """ Lists observations in the specified directory. If clean is True, it will also delete useless observations."""
     obs_stats(obsdir)
@@ -48,6 +65,9 @@ def obs_list(obsdir: str, clean: bool = False):
         if clean and status == ObservationStatus.USELESS:
             print(f"obsdir={obsdir} Deleting useless observation {d.name}...")
             obs_del(obsdir, d.name)
+        if clean and status == ObservationStatus.SUCCESS:
+            print(f"obsdir={obsdir} Cleaning useless files from observation {d.name}...")
+            obs_clean(obsdir, d.name)
 
     print(f"SUMMARY: {total_cnt} observations, {useless_cnt} useless, {unknown_cnt} unknown, {total_cnt - useless_cnt - unknown_cnt} useful.")
 


### PR DESCRIPTION
Here's the problem I'm trying to solve: there are many (over 4K in my case) observation directories with all sorts of artifacts from observations. Many of them are useless junk (e.g. because SDR or antenna was disconnected). This ended up with all sorts of states - useful observations with actual decoded images, useless with various failure modes (just wav file, only log complaining about SDR missing, long wav, but nothing decoded etc.).

This evolved a bit and this PR now contains the following:

- [x] list all locally saved observations and would show their status
- [x] allow deleting useless observations (and raw, wav files if image was decoded from them)
- [x] the server now returns observation id if upload was successful
- [x] the station now logs and writes the upload status to a disk locally
- [x] fixed compatibility problem after sh update to 2.0.6
- [x] submitobs called as stand-alone script now works from a virtualenv
- [x] allow deleting uploaded observations
- [x] save metadata locally, especially if postproc or upload failed

Sadly, it does not contain any new tests...